### PR TITLE
Added framework search paths for watchOS, tvOS and macOS

### DIFF
--- a/VLCKitSwift.xcodeproj/project.pbxproj
+++ b/VLCKitSwift.xcodeproj/project.pbxproj
@@ -1138,6 +1138,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					$SRCROOT/Carthage/Build/iOS,
+				);
 				INFOPLIST_FILE = Configs/VLCKitSwift.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1159,6 +1163,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					$SRCROOT/Carthage/Build/iOS,
+				);
 				INFOPLIST_FILE = Configs/VLCKitSwift.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1181,6 +1189,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					$SRCROOT/Carthage/Build/iOS,
+				);
 				INFOPLIST_FILE = Configs/VLCKitSwift.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1202,6 +1214,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					$SRCROOT/Carthage/Build/iOS,
+				);
 				INFOPLIST_FILE = Configs/VLCKitSwift.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1225,6 +1241,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					$SRCROOT/Carthage/Build/iOS,
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Configs/VLCKitSwift.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1247,6 +1267,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					$SRCROOT/Carthage/Build/iOS,
+				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Configs/VLCKitSwift.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";


### PR DESCRIPTION
This adds the required search paths for watchOS, tvOS and macOS in order for XCode to discover the VLCKit framework built by Carthage.

### Note
It seems strange to me that
```
carthage update --platform tvOS
```
creates the folder `Carthage/Build/iOS` instead of the expected `Carthage/Build/tvOS`. This PR contains the former as the search path for the aforementioned platforms but I'm not sure that this is correct.